### PR TITLE
update requests version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytz == 2017.3
 web3 == 5.12.0
-requests == 2.22.0
+requests == 2.23.0
 eth-keys<0.3.0,>=0.2.1


### PR DESCRIPTION
The current `gql` version in the auction-keeper warns for `requests<2.2.3`. 