### PR TITLE
AccountingEngine.debt_queue() is now total_queued_debt()

### DIFF
--- a/pyflex/gf.py
+++ b/pyflex/gf.py
@@ -705,11 +705,6 @@ class AccountingEngine(Contract):
 
         return bool(self._contract.functions.authorizedAccounts(address.address).call())
 
-    def authorized_accounts(self, address: Address):
-        assert isinstance(address, Address)
-
-        return bool(self._contract.functions.authorizedAccounts(address.address).call())
-
     def contract_enabled(self) -> bool:
         return self._contract.functions.contractEnabled().call() > 0
 
@@ -725,7 +720,7 @@ class AccountingEngine(Contract):
     def debt_auction_house(self) -> Address:
         return Address(self._contract.functions.debtAuctionHouse().call())
 
-    def debt_queue(self) -> Rad:
+    def total_queued_debt(self) -> Rad:
         return Rad(self._contract.functions.totalQueuedDebt().call())
 
     def debt_queue_of(self, block_time: int) -> Rad:
@@ -735,7 +730,7 @@ class AccountingEngine(Contract):
         return Rad(self._contract.functions.totalOnAuctionDebt().call())
 
     def unqueued_unauctioned_debt(self) -> Rad:
-        return (self.safe_engine.debt_balance(self.address) - self.debt_queue()) - self.total_on_auction_debt()
+        return (self.safe_engine.debt_balance(self.address) - self.total_queued_debt()) - self.total_on_auction_debt()
 
     def pop_debt_delay(self) -> int:
         return int(self._contract.functions.popDebtDelay().call())

--- a/tests/test_auctions.py
+++ b/tests/test_auctions.py
@@ -249,7 +249,7 @@ class TestEnglishCollateralAuctionHouse:
         assert safe.locked_collateral == Wad(0)
         assert safe.generated_debt == delta_debt - generated_debt
         assert geb.safe_engine.global_unbacked_debt() > Rad(0)
-        assert geb.accounting_engine.debt_queue() == Rad(amount_to_raise)
+        assert geb.accounting_engine.total_queued_debt() == Rad(amount_to_raise)
         liquidations = geb.liquidation_engine.past_liquidations(1)
         assert len(liquidations) == 1
         last_liquidation = liquidations[0]
@@ -464,7 +464,7 @@ class TestFixedDiscountCollateralAuctionHouse:
         assert safe.locked_collateral == Wad(0)
         assert safe.generated_debt == delta_debt - generated_debt
         assert geb.safe_engine.global_unbacked_debt() > Rad(0)
-        assert geb.accounting_engine.debt_queue() == Rad(amount_to_raise)
+        assert geb.accounting_engine.total_queued_debt() == Rad(amount_to_raise)
         liquidations = geb.liquidation_engine.past_liquidations(1)
         assert len(liquidations) == 1
         last_liquidation = liquidations[0]
@@ -626,7 +626,7 @@ class TestPreSettlementSurplusAuctionHouse:
         # total surplus > total debt + surplus auction amount_to_sell size + surplus buffer
 
         assert joy_before > geb.safe_engine.debt_balance(geb.accounting_engine.address) + geb.accounting_engine.surplus_auction_amount_to_sell() + geb.accounting_engine.surplus_buffer()
-        assert (geb.safe_engine.debt_balance(geb.accounting_engine.address) - geb.accounting_engine.debt_queue()) - \
+        assert (geb.safe_engine.debt_balance(geb.accounting_engine.address) - geb.accounting_engine.total_queued_debt()) - \
                 geb.accounting_engine.total_on_auction_debt() == Rad(0)
         assert geb.accounting_engine.auction_surplus().transact()
         start_auction = surplus_auction_house.auctions_started()
@@ -670,7 +670,7 @@ class TestPreSettlementSurplusAuctionHouse:
         geb.approve_system_coin(our_address)
         assert geb.system_coin_adapter.exit(our_address, Wad(current_bid.amount_to_sell)).transact(from_address=our_address)
         assert geb.system_coin.balance_of(our_address) >= Wad(current_bid.amount_to_sell)
-        assert (geb.safe_engine.debt_balance(geb.accounting_engine.address) - geb.accounting_engine.debt_queue()) - \
+        assert (geb.safe_engine.debt_balance(geb.accounting_engine.address) - geb.accounting_engine.total_queued_debt()) - \
                 geb.accounting_engine.total_on_auction_debt() == Rad(0)
 
         cleanup_safe(geb, geb.collaterals['ETH-A'], deployment_address)

--- a/tests/test_gf.py
+++ b/tests/test_gf.py
@@ -580,7 +580,7 @@ class TestAccountingEngine:
         assert isinstance(geb.accounting_engine.contract_enabled(), bool)
         assert isinstance(geb.accounting_engine.surplus_auction_house(), Address)
         assert isinstance(geb.accounting_engine.debt_auction_house(), Address)
-        assert isinstance(geb.accounting_engine.debt_queue(), Rad)
+        assert isinstance(geb.accounting_engine.total_queued_debt(), Rad)
         assert isinstance(geb.accounting_engine.debt_queue_of(0), Rad)
         assert isinstance(geb.accounting_engine.total_on_auction_debt(), Rad)
         assert isinstance(geb.accounting_engine.unqueued_unauctioned_debt(), Rad)

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -53,7 +53,7 @@ def create_surplus_auction(geb: GfDeployment, deployment_address: Address, our_a
     create_surplus(geb, surplus_auction_house, deployment_address, collateral)
     coin_balance = geb.safe_engine.coin_balance(geb.accounting_engine.address)
     assert coin_balance > geb.safe_engine.debt_balance(geb.accounting_engine.address) + geb.accounting_engine.surplus_auction_amount_to_sell() + geb.accounting_engine.surplus_buffer()
-    assert (geb.safe_engine.debt_balance(geb.accounting_engine.address) - geb.accounting_engine.debt_queue()) - geb.accounting_engine.total_on_auction_debt() == Rad(0)
+    assert (geb.safe_engine.debt_balance(geb.accounting_engine.address) - geb.accounting_engine.total_queued_debt()) - geb.accounting_engine.total_on_auction_debt() == Rad(0)
     assert geb.accounting_engine.auction_surplus().transact()
 
     mint_prot(geb.prot, our_address, Wad.from_number(10))


### PR DESCRIPTION
`AccountingEngine.debt_queue()` is now `total_queued_debt()`.
This matches the contract function name in the `AccountingEngine` contract.